### PR TITLE
Changed numeric ids to strings to avoid conversion error

### DIFF
--- a/WixSharp/Entities/InventoryVariantsResponse.cs
+++ b/WixSharp/Entities/InventoryVariantsResponse.cs
@@ -33,7 +33,7 @@ namespace WixSharp.Entities
         /// Inventory’s unique numeric ID(assigned in ascending order). Primarily for sorting and filtering when crawling all inventories
         /// </summary>
         [JsonProperty("numericId")]
-        public int NumericId { get; set; }
+        public string NumericId { get; set; }
 
         /// <summary>
         /// Variants associated with this inventory item

--- a/WixSharp/Entities/QueryInventoryResponse.cs
+++ b/WixSharp/Entities/QueryInventoryResponse.cs
@@ -40,7 +40,7 @@ namespace WixSharp.Entities
         /// Inventory’s unique numeric ID (assigned in ascending order). Primarily for sorting and filtering when crawling all inventories
         /// </summary>
         [JsonProperty("numericId")]
-        public int NumericId { get; set; }
+        public string NumericId { get; set; }
 
         /// <summary>
         /// Variants associated with this inventory item


### PR DESCRIPTION
As per #7 

Numeric Ids in Wix are too big for an int, changed the numeric id in inventory and inventory variants to a string to match the one in product.